### PR TITLE
Fix readme url on help

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -74,7 +74,7 @@
                 <p class="cmdline">Tooterminal# instance jp<br>shiroma@mstdn.jp# ←インスタンスモード(未ログインの場合はユーザ名が表示されない)</p>
                 <h1>簡易チュートリアル</h1>
                 <p>一般的なクライアント同様、タイムラインの監視とトゥートができるところまでの流れを解説します。</p>
-                <p>詳しい仕様等については<a href="https://github.com/wd-shiroma/tooterminal/blob/master/docs/introduction.md" target="_blank">githubのREADME.md</a>を参照してください。</p>
+                <p>詳しい仕様等については<a href="https://github.com/wd-shiroma/tooterminal/blob/master/docs/README.md" target="_blank">githubのREADME.md</a>を参照してください。</p>
                 <h2>１．インスタンス登録＆インスタンスモードに遷移</h2>
                 <p>特権モードにて以下のコマンドを実行します。</p>
                 <p class="cmdline">Tooterminal# instance インスタンス名(任意)</p>
@@ -93,7 +93,7 @@
                 <h2>３．タイムラインのストリーミング開始とトゥート画面表示</h2>
                 <h3>ストリーミングの再生</h3>
                 <p class="cmdline">userid@domain.domain# terminal monitor</p>
-                <p>ローカルタイムラインと通知が表示されます。ホームタイムラインなどのストリームについては、<a href="https://github.com/wd-shiroma/tooterminal/blob/master/docs/introduction.md" target="_blank">README.md</a>を参照してください。</p>
+                <p>ローカルタイムラインと通知が表示されます。ホームタイムラインなどのストリームについては、<a href="https://github.com/wd-shiroma/tooterminal/blob/master/docs/README.md" target="_blank">README.md</a>を参照してください。</p>
                 <h3>トゥート画面の表示</h3>
                 <p class="cmdline">userid@domain.domain# toot</p>
                 <p>「toot message...」と表示してある入力欄にトゥート内容を書き込んでください。メッセージを隠したい場合は、「contents worning...」の欄に閲覧注意文を入力してください。</p>
@@ -108,7 +108,7 @@
                 <p>Ctrl + Enter　...　トゥート投稿</p>
                 <h1>Q & A</h1>
                 <h3>使い方が分かりません！</h3>
-                <p>とりあえず<a href="https://github.com/wd-shiroma/tooterminal/blob/master/docs/introduction.md" target="_blank">README.md</a>を見てみるのがいいかと…それでわからなかったら#Tooterminalとか付けてトゥートしたらもしかしたら拾うかもしれないです。</p>
+                <p>とりあえず<a href="https://github.com/wd-shiroma/tooterminal/blob/master/docs/README.md" target="_blank">README.md</a>を見てみるのがいいかと…それでわからなかったら#Tooterminalとか付けてトゥートしたらもしかしたら拾うかもしれないです。</p>
                 <h3>難しくて使えません！</h3>
                 <p>当クライアントは俺得を目指して作られたジョーククライアントです。<span style="text-decoration: line-through;">ぶっちゃけ自分もタイムラインの監視にたどり着くのがかなり面倒ってことあります。</span></p>
                 <p>いずれ使いやすくなるような機能を実装したいような気もしているので、それまで頑張ってコマンドをポチポチ打っていただけたらと思います。</p>

--- a/dist/index.html
+++ b/dist/index.html
@@ -93,7 +93,7 @@
                 <h2>３．タイムラインのストリーミング開始とトゥート画面表示</h2>
                 <h3>ストリーミングの再生</h3>
                 <p class="cmdline">userid@domain.domain# terminal monitor</p>
-                <p>ローカルタイムラインと通知が表示されます。ホームタイムラインなどのストリームについては、<a href="https://github.com/wd-shiroma/tooterminal/blob/gh-pages/README.md" target="_blank">README.md</a>を参照してください。</p>
+                <p>ローカルタイムラインと通知が表示されます。ホームタイムラインなどのストリームについては、<a href="https://github.com/wd-shiroma/tooterminal/blob/master/docs/introduction.md" target="_blank">README.md</a>を参照してください。</p>
                 <h3>トゥート画面の表示</h3>
                 <p class="cmdline">userid@domain.domain# toot</p>
                 <p>「toot message...」と表示してある入力欄にトゥート内容を書き込んでください。メッセージを隠したい場合は、「contents worning...」の欄に閲覧注意文を入力してください。</p>
@@ -108,7 +108,7 @@
                 <p>Ctrl + Enter　...　トゥート投稿</p>
                 <h1>Q & A</h1>
                 <h3>使い方が分かりません！</h3>
-                <p>とりあえず<a href="https://github.com/wd-shiroma/tooterminal/blob/gh-pages/README.md" target="_blank">README.md</a>を見てみるのがいいかと…それでわからなかったら#Tooterminalとか付けてトゥートしたらもしかしたら拾うかもしれないです。</p>
+                <p>とりあえず<a href="https://github.com/wd-shiroma/tooterminal/blob/master/docs/introduction.md" target="_blank">README.md</a>を見てみるのがいいかと…それでわからなかったら#Tooterminalとか付けてトゥートしたらもしかしたら拾うかもしれないです。</p>
                 <h3>難しくて使えません！</h3>
                 <p>当クライアントは俺得を目指して作られたジョーククライアントです。<span style="text-decoration: line-through;">ぶっちゃけ自分もタイムラインの監視にたどり着くのがかなり面倒ってことあります。</span></p>
                 <p>いずれ使いやすくなるような機能を実装したいような気もしているので、それまで頑張ってコマンドをポチポチ打っていただけたらと思います。</p>

--- a/dist/index.html
+++ b/dist/index.html
@@ -74,7 +74,7 @@
                 <p class="cmdline">Tooterminal# instance jp<br>shiroma@mstdn.jp# ←インスタンスモード(未ログインの場合はユーザ名が表示されない)</p>
                 <h1>簡易チュートリアル</h1>
                 <p>一般的なクライアント同様、タイムラインの監視とトゥートができるところまでの流れを解説します。</p>
-                <p>詳しい仕様等については<a href="https://github.com/wd-shiroma/tooterminal/blob/gh-pages/README.md" target="_blank">githubのREADME.md</a>を参照してください。</p>
+                <p>詳しい仕様等については<a href="https://github.com/wd-shiroma/tooterminal/blob/master/docs/introduction.md" target="_blank">githubのREADME.md</a>を参照してください。</p>
                 <h2>１．インスタンス登録＆インスタンスモードに遷移</h2>
                 <p>特権モードにて以下のコマンドを実行します。</p>
                 <p class="cmdline">Tooterminal# instance インスタンス名(任意)</p>


### PR DESCRIPTION
In help message, README link is broken. `introduction.md` seems to be same as the previous readme.

please ignore this pr if other better