### PR TITLE
READMEのリンク先を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This client's text is written by Japanese. If you hope any another language, ple
 **一般ユーザの方**
 
 [こちら](https://wd-shiroma.github.io/tooterminal) からTooterminalを利用することが出来ます。  
-操作方法については [ドキュメント](https://github.com/wd-shiroma/tooterminal/tree/master/README.md) を参照してください。
+操作方法については [ドキュメント](https://github.com/wd-shiroma/tooterminal/blob/master/docs/README.md) を参照してください。
 
 **開発に参加してくれる方**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Tooterminalのドキュメントです。
 ## Index
 
 1. Tooterminalについて(工事中)
-2. [とりあえず使えるようになるまでの流れ](https://github.com/wd-shiroma/tooterminal/tree/master/introduction.md)
+2. [とりあえず使えるようになるまでの流れ](https://github.com/wd-shiroma/tooterminal/blob/master/docs/introduction.md)
 3. コマンドリファレンス
   1. グローバルモード(工事中)
   2. コンフィギュレーションモード(工事中)


### PR DESCRIPTION
トップの README.md と docs/README.md のリンク先を修正しました。

- トップの README.md の、`ドキュメント`のリンク先を、docs/README.md に変更
- docs/README.md の、`とりあえず使えるようになるまでの流れ`のリンク先を、docs/introduction.mdに変更